### PR TITLE
43 var directory if missing on make demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 # Virtualenv files (created by tox).
 /build/
 /dist/
+
+# Demo files.
+/var/

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ develop:
 
 #: demo - Install demo project.
 demo: develop
+	mkdir -p var
 	$(DEMO) syncdb --noinput
 	$(DEMO) migrate
 


### PR DESCRIPTION
Proposed fix for #43 

i also noticed that the demo settings reference an `/etc/` directory; should that be included in the `.gitignore` as well?
