### PR TITLE
support Django 1.7, 1.8 in tox.ini and setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ KEYWORDS = [
 ]
 PACKAGES = [NAME.replace('-', '_')]
 REQUIREMENTS = [
-    'Django<1.8',
+    'Django',
     'django-anysign>=0.3',
     'pydocusign>=0.13.1',
     'setuptools',

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,13 @@
 [tox]
-envlist = py27, flake8, sphinx, readme
+envlist = py27-django{17,18}, flake8, sphinx, readme
 
 [testenv]
 deps =
     coverage
     nose
     wheel
+    django17: Django>=1.7,<1.8
+    django18: Django>=1.8,<1.9
 passenv = DOCUSIGN_*
 commands =
     pip install --use-wheel -e ./


### PR DESCRIPTION
Added Django 1.8 to tox config, allowing Django 1.8 for setup.py install. #40, #41

i believe that #42 with it's 1.7 support also handles 1.8 support adequately.