### PR TITLE
Add support for OAuth2 and Send on Behalf of functionality

### DIFF
--- a/django_docusign/backend.py
+++ b/django_docusign/backend.py
@@ -128,7 +128,8 @@ class DocuSignBackend(django_anysign.SignatureBackend):
                 yield document
 
     def create_signature_from_document(self, signature, callback_url=None,
-                                       subject=u'', blurb=u'', sobo_email=None):
+                                       subject=u'', blurb=u'',
+                                       sobo_email=None):
         """Register ``signature`` in DocuSign service, for a signature from
         document.
 
@@ -169,7 +170,8 @@ class DocuSignBackend(django_anysign.SignatureBackend):
         return envelope
 
     def create_signature_from_template(self, signature, callback_url=None,
-                                       subject=u'', blurb=u'', sobo_email=None):
+                                       subject=u'', blurb=u'',
+                                       sobo_email=None):
         """Register ``signature`` in DocuSign service, for a signature from
         document.
 

--- a/django_docusign/backend.py
+++ b/django_docusign/backend.py
@@ -44,6 +44,7 @@ class DocuSignBackend(django_anysign.SignatureBackend):
                     'account_id',
                     'account_url',
                     'app_token',
+                    'oauth2_token',
                     'timeout']:
             setting_name = 'DOCUSIGN_{0}'.format(key.upper())
             try:
@@ -127,7 +128,7 @@ class DocuSignBackend(django_anysign.SignatureBackend):
                 yield document
 
     def create_signature_from_document(self, signature, callback_url=None,
-                                       subject=u'', blurb=u''):
+                                       subject=u'', blurb=u'', sobo_email=None):
         """Register ``signature`` in DocuSign service, for a signature from
         document.
 
@@ -161,13 +162,14 @@ class DocuSignBackend(django_anysign.SignatureBackend):
             status=pydocusign.Envelope.STATUS_SENT,
             documents=documents,
             recipients=signers,
+            sobo_email=sobo_email,
         )
         envelope.envelopeId = self.docusign_client \
                                   .create_envelope_from_documents(envelope)
         return envelope
 
     def create_signature_from_template(self, signature, callback_url=None,
-                                       subject=u'', blurb=u''):
+                                       subject=u'', blurb=u'', sobo_email=None):
         """Register ``signature`` in DocuSign service, for a signature from
         document.
 
@@ -188,13 +190,14 @@ class DocuSignBackend(django_anysign.SignatureBackend):
             status=pydocusign.Envelope.STATUS_SENT,
             templateId=signature.signature_type.docusign_template_id,
             templateRoles=roles,
+            sobo_email=sobo_email,
         )
         envelope.envelopeId = self.docusign_client \
                                   .create_envelope_from_template(envelope)
         return envelope
 
     def create_signature(self, signature, callback_url=None,
-                         subject=u'', blurb=u''):
+                         subject=u'', blurb=u'', sobo_email=None):
         """Register ``signature`` in DocuSign service, return updated object.
 
         This method calls ``save()`` on ``signature``.
@@ -202,10 +205,10 @@ class DocuSignBackend(django_anysign.SignatureBackend):
         """
         if signature.signature_type.docusign_template_id:
             envelope = self.create_signature_from_template(
-                signature, callback_url, subject, blurb)
+                signature, callback_url, subject, blurb, sobo_email)
         else:
             envelope = self.create_signature_from_document(
-                signature, callback_url, subject, blurb)
+                signature, callback_url, subject, blurb, sobo_email)
         # Update signature instance with backend's ID.
         signature.signature_backend_id = envelope.envelopeId
         signature.save()


### PR DESCRIPTION
Replaces PR #57

implements #56

Now passing through the oauth2_token and sobo_email parameters to pydocusign.

This change requires the work from novafloss/pydocusign#76
